### PR TITLE
added a profile for XDEV-IDE deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bin/
 .settings
 .classpath
 .project
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -272,10 +272,6 @@
 
 
 	<profiles>
-
-
-
-
 		<profile>
 			<id>xdev-ide</id>
 
@@ -283,7 +279,7 @@
 				<dependency>
 					<groupId>com.xdev-software</groupId>
 					<artifactId>xapi-fx</artifactId>
-					<version>1.0.0_java8-SNAPSHOT</version>
+					<version>1.0.0-java8-SNAPSHOT</version>
 				</dependency>
 			</dependencies>
 
@@ -301,8 +297,6 @@
 								</goals>
 								<configuration>
 									<createSourcesJar>true</createSourcesJar>
-									
-
 									<transformers>
 
 										<!-- we don't include the MANIFEST.MF files from other jar to avoid 
@@ -326,7 +320,6 @@
 							</execution>
 						</executions>
 					</plugin>
-
 
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
 				<executions>
 					<execution>
 						<id>attach-sources</id>
-						<phase>verify</phase>
+						<phase>package</phase>
 						<goals>
 							<goal>jar-no-fork</goal>
 						</goals>
@@ -270,30 +270,75 @@
 		</plugins>
 	</build>
 
+
 	<profiles>
+
+
+
+
 		<profile>
 			<id>xdev-ide</id>
+
+			<dependencies>
+				<dependency>
+					<groupId>com.xdev-software</groupId>
+					<artifactId>xapi-fx</artifactId>
+					<version>1.0.0_java8-SNAPSHOT</version>
+				</dependency>
+			</dependencies>
+
 			<build>
 				<plugins>
+
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-assembly-plugin</artifactId>
-						<version>3.3.0</version>
-						<configuration>
-							<descriptorRefs>
-								<descriptorRef>jar-with-dependencies</descriptorRef>
-							</descriptorRefs>
-						</configuration>
+						<artifactId>maven-shade-plugin</artifactId>
+						<version>3.2.4</version>
 						<executions>
 							<execution>
-								<id>make-assembly</id>
-								<phase>package</phase>
 								<goals>
-									<goal>single</goal>
+									<goal>shade</goal>
 								</goals>
+								<configuration>
+									<createSourcesJar>true</createSourcesJar>
+									
+
+									<transformers>
+
+										<!-- we don't include the MANIFEST.MF files from other jar to avoid 
+											them from overriding ours -->
+										<transformer
+											implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+											<resource>MANIFEST.MF</resource>
+										</transformer>
+
+										<!-- adding some infos to the MANIFEST.MF -->
+										<transformer
+											implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+											<manifestEntries>
+												<X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
+												<X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
+											</manifestEntries>
+										</transformer>
+
+									</transformers>
+								</configuration>
 							</execution>
 						</executions>
 					</plugin>
+
+
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-dependency-plugin</artifactId>
+						<configuration>
+							<ignoredUnusedDeclaredDependencies>
+								<!-- we don't use that - we are building a fat jar for the IDE -->
+								<ignoredUnusedDeclaredDependencies>com.xdev-software:xapi-fx</ignoredUnusedDeclaredDependencies>
+							</ignoredUnusedDeclaredDependencies>
+						</configuration>
+					</plugin>
+
 				</plugins>
 			</build>
 		</profile>


### PR DESCRIPTION
With `mvn package -Pxdev-ide` you get:

- a jar that contains all classes from xapi and all its dependencies as a fat jar 
- a jar that contains all sources from xapi and all its dependencies as a fat jar 

Check by searching for xdev/ui/XdevBrowser.java/class 